### PR TITLE
fix: guard recursive date conversion against null values

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 An Axios transformer for seamlessly converting ISO 8601 formatted date strings with millisecond precision to JavaScript Date objects. Simplify handling of Date objects in JSON responses with this lightweight utility.
 
+The transformer safely skips `null` values while recursively traversing response objects.
+
 ## Installation
 
 ```sh

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -102,6 +102,39 @@ describe('axios-date-transformer', () => {
         mock.restore();
     });
 
+    test('returns null response data unchanged', async () => {
+        const axiosInstance = initializeAxiosInstance(baseURL);
+        const mock = createMockAdapter(axiosInstance, url, 'null');
+
+        const { data } = await axiosInstance.get(url);
+
+        expect(data).toBeNull();
+
+        mock.restore();
+    });
+
+    test('handles nested null fields without throwing', async () => {
+        const axiosInstance = initializeAxiosInstance(baseURL);
+        const payloadWithNulls = JSON.stringify({
+            createdAt: '2024-01-26T09:45:00.000Z',
+            meta: null,
+            nested: {
+                lastSeenAt: '2024-01-26T09:45:00.000Z',
+                profile: null,
+            },
+        });
+        const mock = createMockAdapter(axiosInstance, url, payloadWithNulls);
+
+        const { data } = await axiosInstance.get(url);
+
+        assertDateConversion(data.createdAt, new Date('2024-01-26T09:45:00.000Z'));
+        expect(data.meta).toBeNull();
+        assertDateConversion(data.nested.lastSeenAt, new Date('2024-01-26T09:45:00.000Z'));
+        expect(data.nested.profile).toBeNull();
+
+        mock.restore();
+    });
+
     test('transforms only date strings in the allowlist', async () => {
         const allowlist = ['beta', 'registeredAt'];
         const axiosInstance = initializeAxiosInstance(baseURL, allowlist);

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,13 +56,15 @@ const shouldConvert = (key: string, value: any, allowlist?: string[]): boolean =
  * @returns The transformed data with Date objects where applicable.
  */
 const recursiveDateConversion = (data: any, allowlist?: string[]): any => {
-    if (typeof data === 'object') {
-        for (const key in data) {
-            if (shouldConvert(key, data[key], allowlist)) {
-                data[key] = new Date(data[key]);
-            } else if (typeof data[key] === 'object') {
-                data[key] = recursiveDateConversion(data[key], allowlist);
-            }
+    if (!data || typeof data !== 'object') {
+        return data;
+    }
+
+    for (const key in data) {
+        if (shouldConvert(key, data[key], allowlist)) {
+            data[key] = new Date(data[key]);
+        } else if (typeof data[key] === 'object') {
+            data[key] = recursiveDateConversion(data[key], allowlist);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent traversal of `null` or non-object values during recursive conversion so the transformer is robust against null payloads and nested null fields.
- Make the behavior explicit by adding tests and documenting null-safe traversal in the README.  

### Description
- Add an early-return guard to `recursiveDateConversion`: `if (!data || typeof data !== 'object') return data;` to avoid iterating `null` or primitives.  
- Add unit tests in `src/index.test.ts` to verify top-level `null` response bodies remain `null` and that nested `null` fields do not cause exceptions while sibling date fields are still converted.  
- Update `README.md` to document that the transformer safely skips `null` values during recursive traversal.  

### Testing
- Ran `npm test` and all tests passed (`1` test suite, `4` tests passed).  
- Ran `npm run build` and the TypeScript build completed successfully.  
- Ran `npm run lint` and the linter passed after a minor formatting fix; `yarn test` failed due to a lockfile/workspace mismatch (tooling mismatch, not a code failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_686e1b927a288327863b425de1adfe49)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved null value handling to safely skip processing when encountering falsy or non-object input values during the transformation process.
* **Tests**
  * Added comprehensive test coverage validating null response data preservation and proper handling of nested null field scenarios without errors.
* **Documentation**
  * Updated documentation to clarify null value handling behavior during recursive object traversal and data transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->